### PR TITLE
Bump develop to cdap 2.7 snapshot dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <app.main.class>co.cask.cdap.guides.traffic.TrafficApp</app.main.class>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>2.6.0-SNAPSHOT</cdap.version>
+    <cdap.version>2.7.0-SNAPSHOT</cdap.version>
     <slf4j.version>1.7.5</slf4j.version>
     <guava.version>13.0.1</guava.version>
     <junit.version>4.11</junit.version>


### PR DESCRIPTION
Currently the tests don't pass due to a bug in CDAP, that is being fixed in 2.6.
