### PR TITLE
Removing enums in TrafficEvent class

### DIFF
--- a/src/main/java/co/cask/cdap/guides/traffic/TrafficEvent.java
+++ b/src/main/java/co/cask/cdap/guides/traffic/TrafficEvent.java
@@ -24,10 +24,10 @@ public class TrafficEvent {
 
   private final String roadSegmentId;
   private final long timestamp;
-  private final Type type;
+  private final String type;
   private final int count;
 
-  public TrafficEvent(String roadSegmentId, long timestamp, Type type, int count) {
+  public TrafficEvent(String roadSegmentId, long timestamp, String type, int count) {
     this.roadSegmentId = roadSegmentId;
     this.timestamp = timestamp;
     this.type = type;
@@ -42,11 +42,22 @@ public class TrafficEvent {
     return timestamp;
   }
 
-  public Type getType() {
+  public String getType() {
     return type;
   }
 
   public int getCount() {
     return count;
+  }
+
+
+  @Override
+  public String toString() {
+    return "TrafficEvent{" +
+      "roadSegmentId='" + roadSegmentId + '\'' +
+      ", timestamp=" + timestamp +
+      ", type=" + type +
+      ", count=" + count +
+      '}';
   }
 }

--- a/src/main/java/co/cask/cdap/guides/traffic/TrafficEventParser.java
+++ b/src/main/java/co/cask/cdap/guides/traffic/TrafficEventParser.java
@@ -94,6 +94,6 @@ public class TrafficEventParser extends AbstractFlowlet {
       return;
     }
 
-    out.emit(new TrafficEvent(parts[0], timestamp, type, count));
+    out.emit(new TrafficEvent(parts[0], timestamp, type.toString(), count));
   }
 }

--- a/src/main/java/co/cask/cdap/guides/traffic/TrafficEventSink.java
+++ b/src/main/java/co/cask/cdap/guides/traffic/TrafficEventSink.java
@@ -37,7 +37,7 @@ public class TrafficEventSink extends AbstractFlowlet {
   public void process(TrafficEvent event) {
     if (event.getCount() > 0) {
       table.increment(Bytes.toBytes(event.getRoadSegmentId()), event.getCount(), event.getTimestamp(),
-                      Bytes.toBytes(event.getType().name()));
+                      Bytes.toBytes(event.getType()));
     } else {
       LOG.info("Skipping event with zero or negative count");
     }


### PR DESCRIPTION
- Having enums in objects that gets passed around in the flowlets has this issue: https://issues.cask.co/browse/CDAP-5862
- Fix this by avoding enums in the guide.
- Relevant JIRA: https://issues.cask.co/browse/CDAP-5862
